### PR TITLE
ci: speed up `clang-tidy` workflow

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Run clang-tidy
         run: |
+          cmake --build build --target opentelemetry_proto
           jq -r .[].file build/compile_commands.json | grep -vE '/(generated|third_party)/' | xargs -P $(nproc) -n 1 clang-tidy --quiet -p build 2>&1 | tee -a clang-tidy.log
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -65,12 +65,12 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          clang-tidy -p build $(jq -r .[].file build/compile_commands.json) 2>&1 | tee -a clang-tidy.log
+          clang-tidy -p build $(jq -r .[].file build/compile_commands.json | grep -vF /generated/) 2>&1 | tee -a clang-tidy.log
 
       - uses: actions/upload-artifact@v4
         with:
           name: Logs (clang-tidy)
-          path: ./build/clang-tidy.log
+          path: ./clang-tidy.log
 
       - name: Count warnings
         run: |

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -46,9 +46,8 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
-          mkdir -p build && cd build
           echo "Running cmake..."
-          cmake .. \
+          cmake -B build \
             -DCMAKE_CXX_STANDARD=14 \
             -DWITH_STL=CXX14 \
             -DWITH_OTLP_HTTP=ON \
@@ -62,13 +61,11 @@ jobs:
             -DBUILD_W3CTRACECONTEXT_TEST=ON \
             -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
             -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCMAKE_CXX_CLANG_TIDY="clang-tidy"
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run clang-tidy
         run: |
-          cd build
-          make 2>&1 | tee -a clang-tidy.log || exit 1
+          clang-tidy -p build $(jq -r .[].file build/compile_commands.json) 2>&1 | tee -a clang-tidy.log
 
       - uses: actions/upload-artifact@v4
         with:
@@ -77,7 +74,6 @@ jobs:
 
       - name: Count warnings
         run: |
-          cd build
           COUNT=$(grep -c "warning:" clang-tidy.log)
           echo "clang-tidy reported ${COUNT} warning(s)"
 

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run clang-tidy
         run: |
-          clang-tidy -p build $(jq -r .[].file build/compile_commands.json | grep -vF /generated/) 2>&1 | tee -a clang-tidy.log
+          jq -r .[].file build/compile_commands.json | grep -vE '/(generated|third_party)/' | xargs -P $(nproc) -n 1 clang-tidy --quiet -p build 2>&1 | tee -a clang-tidy.log
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Changes

This PR makes the `clang-tidy` workflow faster.

Before: 43:06 ([number of warnings](https://github.com/open-telemetry/opentelemetry-cpp/actions/runs/11842952186/job/33002781544#step:7:7): 114)
After: 14:30 ([number of warnings](https://github.com/sjinks/opentelemetry-cpp/actions/runs/11857382383/job/33045627282?pr=1#step:7:6): 114)

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed